### PR TITLE
Allow certificate validation

### DIFF
--- a/networking_dvs/common/config.py
+++ b/networking_dvs/common/config.py
@@ -43,6 +43,9 @@ vmware_opts = [
                help=_("Vsphere password.")),
     cfg.StrOpt('cluster_name', default='',
                help=_("Name of the cluster.")),
+    cfg.StrOpt('ca_certs',
+               default='',
+               help=_("Path to certificates bundle.")),
 ]
 
 dvs_opts = [

--- a/networking_dvs/utils/dvs_util.py
+++ b/networking_dvs/utils/dvs_util.py
@@ -628,6 +628,8 @@ def connect(config, **kwds):
             config.vsphere_password,
             config.api_retry_count,
             config.task_poll_interval,
+            cacert=config.ca_certs,
+            insecure=False if config.ca_certs else True,
             pool_size=config.connections_pool_size,
             **kwds)
         except ConnectionError:


### PR DESCRIPTION
The agent was not validating the vsphere endpoint certificate. It  also led to log spam by urllib.

Note: old behavior is still default to avoid breaking any deployments.