### PR TITLE
Fix agent crash when updating security groups on an existing instance

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
@@ -307,7 +307,7 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         # Get new ports on the VMWare integration bridge
         found_ports = self._scan_ports()
 
-        ports_to_bind = list(six.iterkeys(updated_ports))
+        ports_to_bind = list(self.api.uuid_port_map[port_id] for port_id in six.iterkeys(updated_ports))
 
         for port in found_ports:
             port_segmentation_id = port.get('segmentation_id', None)


### PR DESCRIPTION
updated_ports has the neutron data model from the port_update callback
and not the one from get_devices_details_list, therefore not having
'port_id' and other related properties.