### PR TITLE
Enable security groups rules for rebuilt instances

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
@@ -337,9 +337,16 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         known_ids = six.viewkeys(self.known_ports)
         for port in found_ports:
             port_id = port.get("port_id", None)
-            if port_id and not port_id in known_ids:
+            if not port_id:
+                continue
+            if port_id not in known_ids:
                 added_ports.add(port_id)
                 self.known_ports[port_id] = port
+            else:
+                known_port = self.known_ports[port_id]
+                if port['port_desc'] != known_port['port_desc']:
+                    self.known_ports[port_id] = port
+                    updated_ports[port_id] = port
 
         for port in six.iterkeys(updated_ports):
             self.updated_ports.pop(port, None)

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
@@ -104,7 +104,6 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
             self._ports_by_device_id[port['device']] = port
 
     def _process_ports(self, ports, decrement=False):
-        ports = self._merge_port_info_from_vcenter(ports)
         """
         Process security group settings for port updates
         """

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
@@ -1,4 +1,5 @@
 import pprint
+import copy
 import os
 import eventlet
 if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
@@ -91,7 +92,7 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
         merged_ports = []
         for port in ports: # We skip on missing ports, as we will be called by the dvs_agent for new ports again
             port_id = port['id']
-            vcenter_port = self.v_center.uuid_port_map.get(port_id, None)
+            vcenter_port = copy.deepcopy(self.v_center.uuid_port_map.get(port_id, None))
             if vcenter_port:
                 dict_merge(vcenter_port, port)
                 merged_ports.append(vcenter_port)


### PR DESCRIPTION
On the agent side, neutron wasn't notifying the agent for a port update. This can be detected by comparing the port_desc object in the found vs the known port objects.

Once fixed, on the firewall side the first call to port merge for updates was causing the port_desc to be replaced with an older version, therefore not reassigning the vm. Fixed by copying the vcenter port object before merge.