### PR TITLE
Enable interface attachment and detachment

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -387,6 +387,10 @@ class VCenterMonitor(object):
             elif change_name.startswith("config.hardware.device["):
                 id_end = change_name.index("]")
                 device_key = int(change_name[23:id_end])
+                if "remove" == change.op:
+                    vm_hw.pop(device_key, None)
+                    continue
+                # assume that change.op is assign
                 port_desc = vm_hw.get(device_key, None)
                 if port_desc:
                     attribute = change_name[id_end + 2:]

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -408,6 +408,11 @@ class VCenterMonitor(object):
                     elif "backing.port.portKey" == attribute:
                         port_desc.port_key = str(change.val)
                         self._handle_port_update(port_desc, now)
+                else:
+                    port_desc = self._port_desc_from_nic_change(vmobref, change.val)
+                    if port_desc:
+                        vm_hw[port_desc.device_key] = port_desc
+                        self._handle_port_update(port_desc, now)
 
             elif change_name == 'runtime.powerState':
                 # print("{}: {}".format(vm, change.val))


### PR DESCRIPTION
Tested that port binding and port reassignment works for an existing instance by attaching and detaching new interfaces