### PR TITLE
Remove wrap_retry decorators, will introduce handling for concurrent modifications afterwards

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
@@ -115,7 +115,6 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
                 patched_sg_rules = sg_util._patch_sg_rules(port['security_group_rules'])
                 sg_util.apply_rules(patched_sg_rules, sg_aggr, decrement)
 
-    @dvs_util.wrap_retry
     @stats.timed()
     def _apply_changed_sg_aggr(self):
 

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -539,6 +539,7 @@ class VCenter(object):
             self.security_groups_attribute_key = field.key
 
         if reset_state:
+            wait_pile = False
             pile = GreenPile(self.pool) if self.pool else GreenPile()
             # Will drop all security group rules from matching dvportgroups and remove empty portgroups
             for uuid, dvs in six.iteritems(self.uuid_dvs_map):

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -585,7 +585,6 @@ class VCenter(object):
         return ports_by_switch_and_key
 
     @c_util.stats.timed()
-    @dvs_util.wrap_retry
     def bind_ports(self, ports, callback=None):
         ports_by_switch_and_key = self.ports_by_switch_and_key(ports)
 

--- a/networking_dvs/utils/dvs_util.py
+++ b/networking_dvs/utils/dvs_util.py
@@ -164,7 +164,6 @@ class DVSController(object):
                 except vmware_exceptions.VMwareDriverException as e:
                     if dvs_const.DELETED_TEXT in e.message:
                         pass
-    @wrap_retry
     @stats.timed()
     def _delete_port_group(self, pg_ref, name, ignore_in_use=False):
         while True:
@@ -394,7 +393,6 @@ class DVSController(object):
 
         return result
 
-    @wrap_retry
     @stats.timed()
     def create_dvportgroup(self, sg_attr_key, sg_set, port_config):
         """
@@ -458,7 +456,6 @@ class DVSController(object):
 
         return name
 
-    @wrap_retry
     @stats.timed()
     def update_dvportgroup(self, pg_ref, config_version, port_config=None, name=None):
         if not port_config:


### PR DESCRIPTION
This will allow it to crash (and recover hopefully - quickly)