### PR TITLE
Use a random name during portgroup creation, update after tagging

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -549,10 +549,13 @@ class VCenter(object):
                     if len(pg["vm"]) == 0:
                         pile.spawn(dvs._delete_port_group, pg["ref"], pg["name"], ignore_in_use=True)
                     else:
+                        port_config = dvs.builder.port_setting()
+                        port_config.blocked = dvs.builder.blocked(False)
+                        port_config.filterPolicy = dvs.builder.filter_policy([], None)
                         pile.spawn(dvs.update_dvportgroup,
                                    pg["ref"],
                                    pg["configVersion"],
-                                   port_config=None,
+                                   port_config,
                                    name=dvs.dvportgroup_name(sg_set))
             if wait_pile:
                 for result in pile:


### PR DESCRIPTION
Failure modes are as is

- after creation - an empty, untagged portgroup with a random name is left standing, will not block anything
- after tagging - a tagged portgroup with a random name is left standing, name will be corrected on next agent boot
