### PR TITLE
Set vlan on dvpgs, skipping port binding for matching vlans

### DIFF
--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
@@ -377,8 +377,9 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         for dvs in six.itervalues(self.api.uuid_dvs_map):
             dvs.apply_queued_update_specs()
 
-        LOG.debug("Reporting skipped ports as bound to neutron: {}".format(ports_to_skip))
         for dvs_uuid, ports in six.iteritems(ports_to_skip):
+            LOG.debug("Reporting skipped ports as bound to neutron: {}".format(
+                [port["port_id"] for port in ports]))
             self._bound_ports(self.api.uuid_dvs_map[dvs_uuid],
                               [port['port_desc'].port_key for port in ports],
                               [])

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
@@ -117,6 +117,10 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
                 sg_aggr = self._sg_aggregates_per_dvs_uuid[dvs_uuid][sg_set]
                 patched_sg_rules = sg_util._patch_sg_rules(port['security_group_rules'])
                 sg_util.apply_rules(patched_sg_rules, sg_aggr, decrement)
+                if 'vlan' not in sg_aggr \
+                        and 'vlan' == port.get('network_type', None) \
+                        and port.get('segmentation_id', None):
+                    sg_aggr['vlan'] = port['segmentation_id']
 
     @stats.timed()
     def _apply_changed_sg_aggr(self):
@@ -148,6 +152,8 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
                 sg_set_rules = sg_util.get_rules(sg_aggr)
                 port_config = sg_util.port_configuration(
                         builder, None, sg_set_rules, {}, None, None).setting
+                if 'vlan' in sg_aggr:
+                    port_config.vlan = builder.vlan(sg_aggr['vlan'])
 
                 if sg_set in pg_per_sg:
                     pg = pg_per_sg[sg_set]

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/vcenter_util.py
@@ -312,8 +312,8 @@ class VCenterMonitor(object):
             try:
                 self._run(config)
             except:
-                import traceback, sys
-                traceback.print_exc(file=sys.stdout)
+                import traceback
+                LOG.error(traceback.format_exc())
                 os._exit(1)
 
     def _create_property_filter(self, property_collector, config):


### PR DESCRIPTION
Verified that instances with matching vlans are skipped from port binding while those on a different network but still with the same security groups are configured individually.