### PR TITLE
Pre-create port-group on bind and avoid updates if unchanged

### DIFF
--- a/networking_dvs/api/dvs_agent_rpc_api.py
+++ b/networking_dvs/api/dvs_agent_rpc_api.py
@@ -15,12 +15,12 @@
 import oslo_messaging
 from neutron.common import rpc as n_rpc
 from neutron.common import topics
+from osprofiler.profiler import trace_cls
 
 from networking_dvs.common import constants as dvs_const
 
 
 class ExtendAPI(object):
-
     def create_network(self, context, current, segment):
         self.create_network_precommit(current, segment)
 
@@ -42,7 +42,7 @@ class ExtendAPI(object):
     def delete_port(self, context, current, original, segment):
         self.delete_port_postcommit(current, original, segment)
 
-
+@trace_cls("rpc")
 class DVSClientAPI(object):
     """Client side RPC interface definition."""
     ver = '1.1'

--- a/networking_dvs/common/exceptions.py
+++ b/networking_dvs/common/exceptions.py
@@ -40,31 +40,31 @@ class InvalidNetworkName(InvalidNetwork):
     message = _('Illegal network name %(name)s: %(reason)s')
 
 
-class ResourceNotFond(VMWareDVSException):
+class ResourceNotFound(VMWareDVSException):
     message = _('Resource not found')
 
 
-class DVSNotFound(ResourceNotFond):
+class DVSNotFound(ResourceNotFound):
     message = _('Distributed Virtual Switch %(dvs_name)s not found')
 
 
-class PortGroupNotFound(ResourceNotFond):
+class PortGroupNotFound(ResourceNotFound):
     message = _('Port Group %(pg_name)s not found')
 
 
-class PortNotFound(ResourceNotFond):
+class PortNotFound(ResourceNotFound):
     message = _('Port %(id)s not found')
 
 
-class UnboundPortNotFound(ResourceNotFond):
+class UnboundPortNotFound(ResourceNotFound):
     message = _('Unbound port not found')
 
 
-class HypervisorNotFound(ResourceNotFond):
+class HypervisorNotFound(ResourceNotFound):
     message = _('Hypervisor not found')
 
 
-class VMNotFound(ResourceNotFond):
+class VMNotFound(ResourceNotFound):
     message = _('Virtual machine not found')
 
 

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_agent.py
@@ -23,22 +23,28 @@ if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
 import collections
 import signal
 import six
-
-from oslo_utils import timeutils
+import sys
 
 import oslo_messaging
+
+from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_service import loopingcall
+from oslo_utils import timeutils
+from osprofiler.profiler import trace_cls
 
 import neutron.context
 from neutron.agent import rpc as agent_rpc, securitygroups_rpc as sg_rpc
 from neutron.common import config as common_config, topics, constants as n_const, utils as neutron_utils
+from neutron.common import profiler
 from neutron.i18n import _LI, _LW, _LE
 
 from networking_dvs.agent.firewalls import dvs_securitygroup_rpc as dvs_rpc
-from networking_dvs.common import constants as dvs_constants, config
+from networking_dvs.api import dvs_agent_rpc_api
+from networking_dvs.common import constants as dvs_const, config, exceptions
 from networking_dvs.plugins.ml2.drivers.mech_dvs.agent import vcenter_util
 from networking_dvs.common.util import dict_merge, stats
+from networking_dvs.utils import dvs_util, security_group_utils as sg_util
 
 
 LOG = logging.getLogger(__name__)
@@ -48,16 +54,20 @@ def touch_file(fname, times=None):
     with open(fname, 'a'):
         os.utime(fname, times)
 
+@trace_cls("rpc")
 class DVSPluginApi(agent_rpc.PluginApi):
     pass
 
 
-class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
+@trace_cls("rpc")
+class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
+                      dvs_agent_rpc_api.ExtendAPI):
     target = oslo_messaging.Target(version='1.4')
 
     def __init__(self,
                  quitting_rpc_timeout=None,
-                 conf=None):
+                 conf=None,
+                 ):
 
         super(DvsNeutronAgent, self).__init__()
 
@@ -65,14 +75,18 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
 
         self.conf = conf or CONF
 
+        network_maps = neutron_utils.parse_mappings( self.conf.ML2_VMWARE.network_maps )
+        network_maps_v2 = {}
+
         self.agent_state = {
             'binary': 'neutron-dvs-agent',
             'host': self.conf.host,
             'topic': n_const.L2_AGENT_TOPIC,
             'configurations': {
-                'network_maps': neutron_utils.parse_mappings( self.conf.ML2_VMWARE.network_maps )
+                'network_maps': network_maps,
+                'network_maps_v2': network_maps_v2,
             },
-            'agent_type': dvs_constants.AGENT_TYPE_DVS,
+            'agent_type': dvs_const.AGENT_TYPE_DVS,
             'start_flag': True}
 
         self.setup_rpc()
@@ -83,18 +97,21 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
 
         self.polling_interval = 10
 
+        self.enable_security_groups = self.conf.get('SECURITYGROUP', {}).get('enable_security_group', False)
+
         self.api = vcenter_util.VCenter(self.conf.ML2_VMWARE, pool=self.pool)
 
-        self.enable_security_groups = self.conf.get('SECURITYGROUP', {}).get('enable_security_group', False)
         # Security group agent support
         if self.enable_security_groups:
-            self.api.setup_security_groups_support()
             self.sg_agent = dvs_rpc.DVSSecurityGroupRpc(self.context,
                                                         self.sg_plugin_rpc,
                                                         local_vlan_map=None,
                                                         integration_bridge=self.api,  # Passed on to FireWall Driver
                                                         defer_refresh_firewall=True) # Can only be false, if ...
             # ... we keep track of all the security groups of a port, and probably more changes
+
+        for network, dvs in six.iteritems(self.api.network_dvs_map):
+            network_maps_v2[network] = dvs.uuid.replace(" ", "")
 
         self.run_daemon_loop = True
         self.iter_num = 0
@@ -113,22 +130,40 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         self.catch_sighup = False
         self.connection.consume_in_threads()
 
+    def book_port(self, port, network_segments, network_current):
+        # LOG.debug("{} {} {}".format(port, network_segments, network_current))
+        dvs = None
+        dvs_segment = None
+        for segment in network_segments:
+            if segment['physical_network'] in self.api.network_dvs_map:
+                dvs_segment = segment
+                dvs =  self.api.network_dvs_map[segment['physical_network']]
+
+        sg_set = sg_util.security_group_set(port)
+        dvpg_name = dvs_util.dvportgroup_name(dvs.uuid, sg_set)
+        # First, check if we have that port-group already
+        try:
+            dvs._get_pg_by_name(dvpg_name, refresh_if_missing=False)
+            LOG.debug("Port group exists: %(dvpg_name)s", dvpg_name=dvpg_name)
+            return {'bridge_name': dvpg_name}
+        except exceptions.PortGroupNotFound:
+            LOG.debug("Port group does not exists: %(dvpg_name)s", dvpg_name=dvpg_name)
+            return {}
+
     def port_update(self, context, **kwargs):
+        LOG.info("port_update message {}".format(kwargs))
         port = kwargs.get('port')
         port_id = port['id']
         # Avoid updating a port, which has not been created yet
         if port_id in self.known_ports and not port_id in self.deleted_ports:
             self.updated_ports[port_id] = port
-        LOG.debug("port_update message processed for port {}".format(port_id))
+        LOG.debug("port_update message processed for {}".format(kwargs))
 
     def port_delete(self, context, **kwargs):
         port_id = kwargs.get('port_id')
         self.updated_ports.pop(port_id, None)
         self.deleted_ports.add(port_id)
         LOG.debug("port_delete message processed for port {}".format(port_id))
-
-    def network_create(self, context, **kwargs):
-        LOG.debug(_LI("Agent network_create"))
 
     def network_update(self, context, **kwargs):
         network_id = kwargs['network']['id']
@@ -144,32 +179,29 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
                   {'network_id': network_id,
                    'ports': self.network_ports[network_id]})
 
-    def network_delete(self, context, **kwargs):
-        LOG.debug(_LI("Agent network_delete"))
-
     def setup_rpc(self):
-        self.agent_id = 'dvs-agent-%s' % self.conf.host
-        self.topic = topics.AGENT
         self.plugin_rpc = DVSPluginApi(topics.PLUGIN)
         self.sg_plugin_rpc = sg_rpc.SecurityGroupServerRpcApi(topics.PLUGIN)
+
+        self.agent_id = 'dvs-agent-%s' % self.conf.host
+
+        self.topic = topics.AGENT
         self.state_rpc = agent_rpc.PluginReportStateAPI(topics.PLUGIN)
 
         # RPC network init
         self.context = neutron.context.get_admin_context_without_session()
 
         # Handle updates from service
-        self.endpoints = [self]
+        endpoints = [self]
 
         # Define the listening consumers for the agent
-        consumers = [[topics.PORT, topics.CREATE],
-                     [topics.PORT, topics.UPDATE],
+        consumers = [[topics.PORT, topics.UPDATE],
                      [topics.PORT, topics.DELETE],
-                     [topics.NETWORK, topics.CREATE],
                      [topics.NETWORK, topics.UPDATE],
-                     [topics.NETWORK, topics.DELETE],
-                     [topics.SECURITY_GROUP, topics.UPDATE]]
+                     [topics.SECURITY_GROUP, topics.UPDATE],
+                     [dvs_const.DVS, topics.UPDATE]]
 
-        self.connection = agent_rpc.create_consumers(self.endpoints,
+        self.connection = agent_rpc.create_consumers(endpoints,
                                                      self.topic,
                                                      consumers,
                                                      start_listening=False)
@@ -437,20 +469,14 @@ class DvsNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
         if self.pool:
             self.pool.waitall()
 
-
-def _main():
-    import sys
+def main():
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
+    profiler.setup('neutron-dvs-agent', cfg.CONF.host)
 
-    agent = DvsNeutronAgent()
+    polling_interval = cfg.CONF.AGENT.polling_interval
+    quitting_rpc_timeout = cfg.CONF.AGENT.quitting_rpc_timeout
 
-    # Start everything.
-    LOG.info(_LI("Agent initialized successfully, now running... "))
-    agent.daemon_loop()
-
-
-def main():
     try:
         resolution = float(os.getenv('DEBUG_BLOCKING'))
         import eventlet.debug
@@ -459,22 +485,10 @@ def main():
         pass
 
     try:
-        import yappi as profiler
+        agent = DvsNeutronAgent()
 
-        profiler.set_clock_type('wall')
-        profiler.start(builtins=True)
-    except ImportError:
-        profiler = None
-        pass
-
-    try:
-        _main()
+        # Start everything.
+        LOG.info(_LI("Agent initialized successfully, now running... "))
+        agent.daemon_loop()
     except KeyboardInterrupt:
         pass
-
-    if profiler:
-        print("Stopping profiler")
-        profiler.stop()
-        stats = profiler.get_func_stats()
-        stats.save('/tmp/profile.callgrind', type='callgrind')
-        print("Done")

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/agent/dvs_firewall.py
@@ -1,14 +1,14 @@
-import pprint
 import copy
 import os
 import eventlet
 if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
     eventlet.monkey_patch()
 
-from eventlet.greenpool import GreenPile
+from eventlet.greenpool import GreenPool
 
 import six
-from collections import defaultdict, deque
+from collections import defaultdict, Counter
+from functools import partial
 
 from neutron.agent import firewall
 from neutron.i18n import _LE, _LW, _LI
@@ -24,12 +24,14 @@ from networking_dvs.plugins.ml2.drivers.mech_dvs.agent import vcenter_util
 LOG = logging.getLogger(__name__)
 CONF = config.CONF
 
+def _uncurry(_, f, *args, **keywords):
+    return f(*args, **keywords)
 
 class DvsSecurityGroupsDriver(firewall.FirewallDriver):
     def __init__(self, integration_bridge=None):
         self.v_center = integration_bridge if isinstance(integration_bridge, VCenter) else VCenter(self.conf.ML2_VMWARE)
         self._ports_by_device_id = {}  # Device-id seems to be the same as port id
-        self._sg_aggregates_per_dvs_uuid = defaultdict(lambda : defaultdict(dict))
+        self._sg_aggregates_per_dvs_uuid = defaultdict(lambda : defaultdict(sg_util.SgAggr))
         self._green = self.v_center.pool or eventlet
 
     def prepare_port_filter(self, ports):
@@ -37,7 +39,7 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
         merged_ports = self._merge_port_info_from_vcenter(ports)
         self._update_ports_by_device_id(merged_ports)
         self._process_ports(merged_ports)
-        self._apply_changed_sg_aggr()
+        self._apply_changed_sg_aggregates()
 
     def apply_port_filter(self, ports):
         # This driver does all of its processing during the prepare_port_filter call
@@ -54,7 +56,7 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
         self._update_ports_by_device_id(merged_ports)
 
         self._process_ports(merged_ports)
-        self._apply_changed_sg_aggr()
+        self._apply_changed_sg_aggregates()
 
     def remove_port_filter(self, port_ids):
         # LOG.debug("remote_port_filter called for %s", pprint.pformat(port_ids))
@@ -62,7 +64,7 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
                            for port_id in port_ids
                            if port_id in self._ports_by_device_id]
         self._process_ports(ports_to_remove, decrement=True)
-        self._apply_changed_sg_aggr()
+        self._apply_changed_sg_aggregates()
         for port_id in port_ids:
             self._ports_by_device_id.pop(port_id, None)
 
@@ -112,108 +114,88 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
                     LOG.debug("Port {} has no security group set, skipping processing.".format(port['id']))
                     continue
                 sg_aggr = self._sg_aggregates_per_dvs_uuid[dvs_uuid][sg_set]
-                if 'ports' not in sg_aggr:
-                    sg_aggr['ports'] = deque()
 
                 # Schedule for reassignment
                 if not decrement:
-                    if 'dvpg-key' in sg_aggr:
-                        if port['port_desc'].port_group_key != sg_aggr['dvpg-key']:
-                            sg_aggr['ports'].append(port)
-                        # else: port is properly assigned, no need to reassign
-                    else:
-                        sg_aggr['ports'].append(port)
+                    if port['port_desc'].port_group_key != sg_aggr.pg_key:
+                        sg_aggr.ports_to_assign.append(port)
 
                 # Prepare and apply rules to the sg_aggr
                 patched_sg_rules = sg_util._patch_sg_rules(port['security_group_rules'])
                 sg_util.apply_rules(patched_sg_rules, sg_aggr, decrement)
 
-                # Store the first found vlan in the ag_aggr
-                if 'vlan' not in sg_aggr \
-                        and 'vlan' == port.get('network_type', None) \
-                        and port.get('segmentation_id', None):
-                    sg_aggr['vlan'] = port['segmentation_id']
+    def _apply_changed_sg_aggr(self, dvs, sg_set, sg_aggr):
+        client_factory = dvs.connection.vim.client.factory
+        builder = sg_util.PortConfigSpecBuilder(client_factory)
+        pg_per_sg = dvs.get_port_group_by_security_group()
+
+        if not sg_aggr.dirty:
+            if sg_aggr.pg_key:
+                self._reassign_ports(sg_aggr)
+            return
+
+        # Mark as processed, might be reset below
+        sg_aggr.dirty = False
+
+        # Prepare a port config
+        sg_set_rules = sg_util.get_rules(sg_aggr)
+        port_config = sg_util.port_configuration(
+                builder, None, sg_set_rules, {}, None, None).setting
+        if sg_aggr.vlan:
+            port_config.vlan = builder.vlan(sg_aggr.vlan)
+
+        pg = pg_per_sg.get(sg_set, None)
+        if pg:
+            sg_aggr.pg_key = pg["key"]
+            if len(sg_set_rules) == 0:
+                LOG.debug("No rules left")
+            else:
+                dvs.update_dvportgroup(pg, port_config)
+            self._reassign_ports(sg_aggr)
+        else:
+            self._create_dvpg_and_update_sg_aggr(dvs,
+                                                 sg_set,
+                                                 port_config,
+                                                 sg_aggr)
 
     @stats.timed()
-    def _apply_changed_sg_aggr(self):
+    def _apply_changed_sg_aggregates(self):
+        pool = self.v_center.pool or GreenPool()
 
-        local_pile = _pile(self.v_center.pool)
-        local_pile.spawn(noop) # See https://github.com/eventlet/eventlet/issues/53
-
-        for dvs_uuid, sg_aggregates in six.iteritems(self._sg_aggregates_per_dvs_uuid):
-
+        def _apply(dvs_uuid, sg_aggregates):
             dvs = self.v_center.get_dvs_by_uuid(dvs_uuid)
-            client_factory = dvs.connection.vim.client.factory
-            builder = sg_util.PortConfigSpecBuilder(client_factory)
-            pg_per_sg = dvs.get_pg_per_sg_attribute(self.v_center.security_groups_attribute_key)
-            obsolete_sg_sets = []
+            apply_on_dvs = partial(self._apply_changed_sg_aggr, dvs)
 
-            for sg_set, sg_aggr in six.iteritems(sg_aggregates):
-                if "dvpg-key" in sg_aggr:
-                    self._reassign_ports(sg_aggr)
+            for result in pool.starmap(apply_on_dvs, six.iteritems(sg_aggregates)):
+                pass
 
-                if not sg_aggr["dirty"]:
-                    continue
-
-                if 'gt' not in sg_aggr:
-                    sg_aggr['gt'] = self._green.spawn(noop)
-
-                # Mark as processed, might be reset bellow
-                sg_aggr["dirty"] = False
-
-                # Prepare a port config
-                sg_set_rules = sg_util.get_rules(sg_aggr)
-                port_config = sg_util.port_configuration(
-                        builder, None, sg_set_rules, {}, None, None).setting
-                if 'vlan' in sg_aggr:
-                    port_config.vlan = builder.vlan(sg_aggr['vlan'])
-
-                if sg_set in pg_per_sg:
-                    pg = pg_per_sg[sg_set]
-                    if len(sg_set_rules) == 0:
-                        if len(pg["vm"]) == 0:
-                            sg_aggr['gt'].link(_delete_dvpg, dvs, pg["ref"], pg["name"], True)
-                            obsolete_sg_sets.append(sg_set)
-                            continue
-                        else:
-                            # Keep the dirty flag, so that we retry deleting it on the next run
-                            sg_aggr["dirty"] = True
-                    else:
-                        sg_aggr['gt'].link(_update_dvpg, dvs, pg["ref"], pg["configVersion"], port_config)
-                    sg_aggr["dvpg-key"] = pg["key"]
-                else:
-                    local_pile.spawn(
-                        self._create_dvpg_and_update_sg_aggr,
-                        dvs,
-                        self.v_center.security_groups_attribute_key,
-                        sg_set,
-                        port_config,
-                        sg_aggr)
-
-            # Release no-longer used sg_aggr objects
-            for obsolete_sg_set in obsolete_sg_sets:
-                del sg_aggregates[obsolete_sg_set]
-
-        # Wait new dvpg creations, necessary for vm reassignments
-        for result in local_pile:
+        for result in pool.starmap(_apply, six.iteritems(self._sg_aggregates_per_dvs_uuid)):
             pass
 
     def _reassign_ports(self, sg_aggr):
         """
         Reassigns VM to a dvportgroup based on its port's security group set
         """
-        ports = sg_aggr.get('ports', None)
+
+        ports = sg_aggr.ports_to_assign
+        sg_aggr.ports_to_assign = []
+
+        if not sg_aggr.vlan:
+            vlan_ids = Counter([ port['segmentation_id']
+                    for port in ports
+                    if 'vlan' == port.get('network_type', None) and port.get('segmentation_id', None) ])
+            sg_aggr.vlan, _ = vlan_ids.most_common(1)[0]
+
         port_keys_to_drop = defaultdict(list)
-        while len(ports) > 0:
-            port = ports.popleft()
+        for port in ports:
             sg_set = sg_util.security_group_set(port)
             if not sg_set:
                 LOG.debug("Port {} has no security group set, skipping reassignment.".format(port['id']))
                 continue
             port_desc = port['port_desc']
-            if port_desc.port_group_key == sg_aggr['dvpg-key']:
+            if port_desc.port_group_key == sg_aggr.pg_key:
                 # Existing ports can enter the reassignment queue
-                # on agent boot before the dvpg-key has been set
+                # on agent boot before the pg_key has been set
                 # on the sg_aggr object. Filter them here.
                 continue
             dvs_uuid = port_desc.dvs_uuid
@@ -223,7 +205,7 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
             # Configure the backing to the required dvportgroup
             port_connection = client_factory.create('ns0:DistributedVirtualSwitchPortConnection')
             port_connection.switchUuid = dvs_uuid
-            port_connection.portgroupKey = sg_aggr['dvpg-key']
+            port_connection.portgroupKey = sg_aggr.pg_key
             port_backing = client_factory.create('ns0:VirtualEthernetCardDistributedVirtualPortBackingInfo')
             port_backing.port = port_connection
 
@@ -261,18 +243,10 @@ class DvsSecurityGroupsDriver(firewall.FirewallDriver):
 
         eventlet.sleep(0) # yield to allow VM network reassignments to take place
 
-    def _create_dvpg_and_update_sg_aggr(self, dvs, sg_attr_key, sg_set, port_config, sg_aggr):
-        pg = dvs.create_dvportgroup(sg_attr_key, sg_set, port_config)
-        sg_aggr["dvpg-key"] = pg["key"]
+    def _create_dvpg_and_update_sg_aggr(self, dvs, sg_set, port_config, sg_aggr):
+        pg = dvs.create_dvportgroup(sg_set, port_config)
+        sg_aggr.pg_key = pg["key"]
         self._reassign_ports(sg_aggr)
-
-def _delete_dvpg(gt, dvs, pg_ref, pg_name, ignore_in_use):
-    """ Delete dvportgroup function for use with greenthreads' link """
-    dvs._delete_port_group(pg_ref, pg_name, ignore_in_use)
-
-def _update_dvpg(gt, dvs, pg_ref, config_version, port_config):
-    """ Update dvportgroup function for use with greenthreads' link """
-    dvs.update_dvportgroup(pg_ref, config_version, port_config)
 
 @stats.timed()
 def reconfig_vm(dvs, vm_ref, vm_config_spec):
@@ -295,10 +269,3 @@ def _ports_by_switch(ports=None):
 
 def noop(*args):
     pass
-
-def _pile(pool=None):
-    if pool:
-        return GreenPile(pool)
-    else:
-        return GreenPile()
-#

--- a/networking_dvs/plugins/ml2/drivers/mech_dvs/driver.py
+++ b/networking_dvs/plugins/ml2/drivers/mech_dvs/driver.py
@@ -19,9 +19,12 @@ from neutron.extensions import portbindings
 from neutron.i18n import _LI
 from neutron.plugins.common import constants as p_constants
 
+from neutron import context
 from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2.drivers import mech_agent
+from networking_dvs.api import dvs_agent_rpc_api
 from networking_dvs.common import constants as dvs_constants
+from networking_dvs.utils import dvs_util, security_group_utils as sg_util
 
 LOG = log.getLogger(__name__)
 
@@ -39,12 +42,14 @@ class VMwareDVSMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         LOG.info(_LI("VMware DVS mechanism driver initializing..."))
         self.agent_type = dvs_constants.AGENT_TYPE_DVS
         self.vif_type = dvs_constants.DVS
+        self.version = 1
 
         sg_enabled = securitygroups_rpc.is_firewall_enabled()
         self.vif_details = {portbindings.CAP_PORT_FILTER: sg_enabled,
                             portbindings.OVS_HYBRID_PLUG: sg_enabled,
                             }
-
+        self.context = context.get_admin_context_without_session()
+        self.dvs_notifier = dvs_agent_rpc_api.DVSClientAPI(self.context)
         super(VMwareDVSMechanismDriver, self).__init__(
             self.agent_type,
             self.vif_type,
@@ -56,14 +61,18 @@ class VMwareDVSMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         return ([p_constants.TYPE_VLAN, p_constants.TYPE_FLAT])
 
     def get_mappings(self, agent):
-        return agent['configurations'].get('network_maps', {'default': 'dvSwitch0'})
+        config = agent['configurations']
+        if 'network_maps_v2' in config:
+            self.version = 2
+            return config['network_maps_v2']
+        else:
+            self.version = 1
+            return config.get('network_maps', {'default': 'dvSwitch0'})
 
     def try_to_bind_segment_for_agent(self, context, segment, agent):
-        LOG.info(_LI("try_to_bind_segment_for_agent"))
-        LOG.info(context.current)
-
+        port = context.current
         # We only do compute devices
-        device_owner = context.current['device_owner']
+        device_owner = port['device_owner']
 
         if not device_owner or not device_owner.startswith('compute'):
             return False
@@ -76,8 +85,7 @@ class VMwareDVSMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         agent_host = agent.get('host', None)
 
         # If the agent is bound to a host, then it can only handle those
-
-        if agent_host and agent_host != context.current['binding:host_id']:
+        if agent_host != port['binding:host_id']:
             return False
 
         mappings = self.get_mappings(agent)
@@ -92,6 +100,15 @@ class VMwareDVSMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         if not bridge_name:
             return False
 
+        if self.version == 2:
+            response = self.dvs_notifier.bind_port_call(port,
+                                                context.network.network_segments,
+                                                context.network.current,
+                                                context.host
+                                                )
+            if response and 'bridge_name' in response:
+                bridge_name = response['bridge_name']
+
         vif_details = self.vif_details.copy()
         vif_details['bridge_name'] = bridge_name
 
@@ -100,44 +117,3 @@ class VMwareDVSMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                             vif_details)
         return True
 
-    def create_network_precommit(self, context):
-        LOG.info(_LI("create_network_precommit"))
-        # self.vmware_util.create_dvpg(context)
-
-    def delete_network_precommit(self, context):
-        LOG.info(_LI("delete_network_precommit"))
-        # self.vmware_util.delete_dvpg(context)
-
-    #
-    # def update_network_precommit(self, context):
-    #     self.vmware_util.update_dvpg(context)
-    #
-    # def bind_port(self, context):
-    #     LOG.info(_LI("********************** bind_port port %(port)s on "
-    #                  "network %(network)s "+context.host
-    #                  ),
-    #              {'port': context.current['id'],
-    #               'network': context.network.current['id']
-    #               })
-    #     return
-    #
-    #
-    #     for segment in context.network.network_segments:
-    #         context.set_binding(segment[api.ID],
-    #                             self.vif_type,
-    #                             self.vif_details,
-    #                             status=n_const.PORT_STATUS_ACTIVE)
-    #
-    #
-    #
-    def create_port_precommit(self, context):
-        LOG.info(_LI("*********************** create_port_precommit port %(port)s on "
-                     "network %(network)s"),
-                 {'port': context.current['id'],
-                  'network': context.network.current['id']})
-
-    def create_port_postcommit(self, context):
-        LOG.info(_LI("*********************** create_port_postcommit port %(port)s on "
-                     "network %(network)s"),
-                 {'port': context.current['id'],
-                  'network': context.network.current['id']})

--- a/networking_dvs/utils/dvs_util.py
+++ b/networking_dvs/utils/dvs_util.py
@@ -13,9 +13,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from collections import defaultdict
 from time import sleep
 import hashlib
 import re
+import itertools
 import six
 import string
 import uuid
@@ -62,6 +64,60 @@ def wrap_retry(func):
                     raise
     return wrapper
 
+
+def dvportgroup_name(uuid, sg_set):
+    """
+    Returns a dvportgroup name for the particular security group set
+    in the context of the switch of the given uuid
+    """
+    # There is an upper limit on managed object names in vCenter
+    dvs_id = ''.join(uuid.split(' '))[:8]
+    name = sg_set + "-" + dvs_id
+    if len(name) > 80:
+        # so we use a hash of the security group set
+        hex = hashlib.sha224()
+        hex.update(sg_set)
+        name = hex.hexdigest() + "-" + dvs_id
+
+    return name
+
+
+def _config_differs(current, update):
+    if current.__class__ != update.__class__:
+        return True
+
+    for name, value in current:
+        try:
+            new_value = update[name]
+            if not new_value or 'inherited' in new_value and new_value['inherited'] is None:
+                continue
+
+            if isinstance(value, list):
+                if len(value) != len(new_value):
+                    return True
+                for a, b in itertools.izip(value, new_value):
+                    if _config_differs(a, b):
+                        return True
+                continue
+
+            if hasattr(value, '__keylist__'):
+                if _config_differs(value, new_value):
+                    return True
+                else:
+                    continue
+
+            if value != new_value:
+                return True
+        except KeyError:
+            pass
+        except TypeError, e:
+            if value != new_value:
+                LOG.error(name)
+                LOG.error(value)
+                LOG.error(new_value)
+                return False
+    return False
+
 class DVSController(object):
     """Controls one DVS."""
 
@@ -78,6 +134,8 @@ class DVSController(object):
             self.connection.vim.client.factory)
         self.hosts_to_rectify = {}
         self.rectify_wait = rectify_wait
+
+        self._port_groups_by_name = {}
         try:
             self._dvs, self._datacenter = self._get_dvs(dvs_name, connection)
             # (SlOPS) To do release blocked port after use
@@ -111,6 +169,7 @@ class DVSController(object):
             raise exceptions.wrap_wmvare_vim_exception(e)
         else:
             pg = result.result
+            self._port_groups_by_name[name] = pg
             LOG.info(_LI('Network %(name)s created \n%(pg_ref)s'),
                      {'name': name, 'pg_ref': pg})
             return pg
@@ -178,19 +237,21 @@ class DVSController(object):
                     pg_ref)
                 self.connection.wait_for_task(pg_delete_task)
                 LOG.info(_LI('Network %(name)s deleted.') % {'name': name})
-                break
+                self._port_groups_by_name.pop(name, None)
+                return True
             except vmware_exceptions.VimException as e:
-                if not ignore_in_use or not re.match("The resource '\d*' is in use.", e.message):
-                    raise exceptions.wrap_wmvare_vim_exception(e)
-                else:
+                if ignore_in_use and 'ResourceInUse' in e.fault_list:
                     LOG.warn(_LW("Could not delete port-group %(name)s. Reason: %(message)s")
-                             % {'name': name, 'message': e.message})
-                    break
+                            % {'name': name, 'message': e.message})
+                    return False
+                else:
+                    raise exceptions.wrap_wmvare_vim_exception(e)
             except vmware_exceptions.VMwareDriverException as e:
                 if dvs_const.DELETED_TEXT in e.message:
-                    sleep(0.1)
+                    return True
                 else:
                     raise
+        return False
 
     def submit_update_ports(self, update_specs):
         return self.connection.invoke_api(
@@ -344,23 +405,21 @@ class DVSController(object):
                             setattr(existing_spec.setting, attr, getattr(spec.setting, attr))
         return callbacks, update_specs_by_key
 
-    def get_pg_per_sg_attribute(self, sg_attr_key, max_objects=100):
+    def get_port_group_by_security_group(self, max_objects=100):
         portgroups = self._get_portgroups(max_objects)
         result = {}
 
-        for dvpg in portgroups:
-            if "customValue" not in dvpg:
-                continue
-
-            if dvpg["customValue"].__class__.__name__ == "ArrayOfCustomFieldValue":
-                for custom_field_value in dvpg["customValue"]["CustomFieldValue"]:
-                    if custom_field_value.key == sg_attr_key:
-                        result[custom_field_value.value] = dvpg
-                        break
+        for dvpg in six.itervalues(portgroups):
+            description = dvpg["description"]
+            if description:
+                result[dvpg["description"]] = dvpg
 
         return result
 
-    def _get_portgroups(self, max_objects=100):
+    def _get_portgroups(self, max_objects=100, refresh=False):
+        if self._port_groups_by_name and not refresh:
+            return self._port_groups_by_name
+
         """Get all portgroups on the switch"""
         vim = self.connection.vim
         property_collector = vim.service_content.propertyCollector
@@ -379,7 +438,7 @@ class DVSController(object):
         property_spec = vim_util.build_property_spec(
                 vim.client.factory,
                 "DistributedVirtualPortgroup",
-                ["key", "name", "config.configVersion", "customValue", "vm"])
+                ["key", "name", "config.description", "config.configVersion", "config.defaultPortConfig"])
 
         property_filter_spec = vim_util.build_property_filter_spec(
                 vim.client.factory,
@@ -390,22 +449,23 @@ class DVSController(object):
 
         pc_result = vim.RetrievePropertiesEx(property_collector, specSet=[property_filter_spec],
                 options=options)
-        result = []
 
         with vim_util.WithRetrieval(vim, pc_result) as pc_objects:
             for objContent in pc_objects:
                 props = {prop.name : prop.val for prop in objContent.propSet}
                 props["ref"] = objContent.obj
-                props["configVersion"] = props["config.configVersion"]
-                result.append(props)
+                props["configVersion"] = int(props.pop("config.configVersion", 0))
+                props["description"] = str(props.pop("config.description", ""))
+                props["defaultPortConfig"] = props.pop("config.defaultPortConfig", None)
+                self._port_groups_by_name[props["name"]] = props
 
-        return result
+        return self._port_groups_by_name
 
     @stats.timed()
-    def create_dvportgroup(self, sg_attr_key, sg_set, port_config):
+    def create_dvportgroup(self, sg_set, port_config, update=True):
         """
         Creates an automatically-named dvportgroup on the dvswitch
-        with the specified sg rules and marks it as such through a custom attribute
+        with the specified sg rules and marks it as such through the description
 
         Returns a dictionary with "key" and "ref" keys.
 
@@ -419,7 +479,7 @@ class DVSController(object):
         # which seems to be part of a non-used call path
         # starting from the dvs_agent_rpc_api. TODO - remove it
 
-        dvpg_name = self.dvportgroup_name(sg_set)
+        dvpg_name = dvportgroup_name(self.uuid, sg_set)
 
         try:
             pg_spec = self.builder.pg_config(port_config)
@@ -438,94 +498,92 @@ class DVSController(object):
 
             pg_ref = result.result
 
-            # Tag the portgroup for the specific security group set
-            self.connection.invoke_api(
-                self.connection.vim,
-                "SetField",
-                self._service_content.customFieldsManager,
-                entity=pg_ref,
-                key=sg_attr_key,
-                value=sg_set)
-
             props = vim_util.get_object_properties_dict(self.connection.vim, pg_ref, ["key"])
             delta = timeutils.utcnow() - now
             stats.timing('networking_dvs.dvportgroup.created', delta)
             LOG.debug("Creating portgroup {} took {} seconds.".format(pg_ref.value, delta.seconds))
-            return {"key": props["key"], "ref": pg_ref}
+
+            values = {"key": props["key"],
+                      "ref": pg_ref,
+                      "configVersion": 0,
+                      "description": sg_set,
+                      "defaultPortConfig": port_config
+                      }
+            self._port_groups_by_name[dvpg_name] = values
+            return values
         except vmware_exceptions.DuplicateName as dn:
             LOG.info("Untagged portgroup with matching name {} found, will update and use.".format(dvpg_name))
             portgroups = self._get_portgroups()
-            for existing in portgroups:
-                if existing['name'] != dvpg_name:
-                    continue
-                break # found it
-            else:
+            if dvpg_name not in portgroups:
+                portgroups = self._get_portgroups(refresh=True)
+
+            if dvpg_name not in portgroups:
                 LOG.error("Portgroup with matching name {} not found while expected.".format(dvpg_name))
                 return
 
-            self.update_dvportgroup(existing["ref"], existing["config.configVersion"], port_config)
+            existing = portgroups[dvpg_name]
 
-            # Tag the portgroup for the specific security group set
-            self.connection.invoke_api(
-                self.connection.vim,
-                "SetField",
-                self._service_content.customFieldsManager,
-                entity=existing["ref"],
-                key=sg_attr_key,
-                value=sg_set)
+            if update:
+                self.update_dvportgroup(existing, port_config)
 
             return existing
         except vmware_exceptions.VimException as e:
             raise exceptions.wrap_wmvare_vim_exception(e)
 
-    def dvportgroup_name(self, sg_set):
-        """
-        Returns a dvportgroup name for the particular security group set
-        in the context of the current switch
-        """
-        # There is an upper limit on managed object names in vCenter
-        dvs_id = ''.join(self.uuid.split(' '))[:8]
-        name = sg_set + "-" + dvs_id
-        if len(name) > 80:
-            # so we use a hash of the security group set
-            hex = hashlib.sha224()
-            hex.update(sg_set)
-            name = hex.hexdigest() + "-" + dvs_id
-
-        return name
-
     @stats.timed()
-    def update_dvportgroup(self, pg_ref, config_version, port_config=None, name=None, retries=3):
-        if retries <= 0:
-            LOG.error("Maximum number of update retries reached for portgroup {}.".format(pg_ref.value))
-            return
-        try:
-            pg_spec = self.builder.pg_config(port_config)
-            pg_spec.configVersion = config_version
-            if name:
-                pg_spec.name = name
+    def update_dvportgroup(self, pg, port_config=None, name=None, retries=3):
+        for ntry in six.moves.xrange(retries):
+            pg_ref = pg["ref"]
+            name = name or pg.get("name")
+            if not name:
+                LOG.debug("Missing name for %s", pg_ref.value)
 
-            now = timeutils.utcnow()
-            pg_update_task = self.connection.invoke_api(
-                self.connection.vim,
-                'ReconfigureDVPortgroup_Task',
-                pg_ref, spec=pg_spec)
+            default_port_config = pg.get("defaultPortConfig")
 
-            self.connection.wait_for_task(pg_update_task)
-            delta = timeutils.utcnow() - now
-            stats.timing('networking_dvs.dvportgroup.updated', delta)
-            LOG.debug("Updating portgroup {} took {} seconds.".format(pg_ref.value, delta.seconds))
-        except vmware_exceptions.VimException as e:
-            if dvs_const.CONCURRENT_MODIFICATION_TEXT in str(e):
-                LOG.debug("Concurrent modification detected, will retry.")
-                config_version = vim_util.get_object_property(
-                    self.connection.vim, pg_ref, "config.configVersion")
-                return self.update_dvportgroup(pg_ref, config_version, port_config, name, retries-1)
-            if dvs_const.BULK_FAULT_TEXT in str(e):
-                info = get_task_info(self.connection, pg_update_task)
-                self.rectifyForFault(info.error.fault)
+            if name == pg.get("name") \
+                    and (default_port_config or not port_config) \
+                    and not _config_differs(default_port_config, port_config):
+                LOG.debug("Skipping update: No changes to known config on %s", (name))
                 return
-            raise exceptions.wrap_wmvare_vim_exception(e)
+
+            try:
+                pg_spec = self.builder.pg_config(port_config)
+                pg_spec.configVersion = str(pg["configVersion"])
+                if name and name != pg["name"]:
+                    pg_spec.name = name
+
+                now = timeutils.utcnow()
+                pg_update_task = self.connection.invoke_api(
+                    self.connection.vim,
+                    'ReconfigureDVPortgroup_Task',
+                    pg_ref, spec=pg_spec)
+
+                pg["configVersion"] += 1
+                pg["defaultPortConfig"] = port_config
+
+                self.connection.wait_for_task(pg_update_task)
+
+                delta = timeutils.utcnow() - now
+                stats.timing('networking_dvs.dvportgroup.updated', delta)
+
+                LOG.debug("Updating portgroup {} took {} seconds.".format(pg_ref.value, delta.seconds))
+                return
+            except vmware_exceptions.VimException as e:
+                if dvs_const.CONCURRENT_MODIFICATION_TEXT in str(e) \
+                        and ntry != retries-1:
+                    LOG.debug("Concurrent modification detected, will retry.")
+                    ## TODO A proper read-out of the current config
+                    config_version = vim_util.get_object_property(
+                        self.connection.vim, pg_ref, "config.configVersion")
+
+                    continue
+
+                if dvs_const.BULK_FAULT_TEXT in str(e):
+                    info = get_task_info(self.connection, pg_update_task)
+                    self.rectifyForFault(info.error.fault)
+                    return
+                raise exceptions.wrap_wmvare_vim_exception(e)
+
 
     def rectifyForFault(self, fault):
         """
@@ -542,7 +600,7 @@ class DVSController(object):
                     self.hosts_to_rectify[host_ref] = time.time()
                     hosts.add(host_ref)
                 else:
-                    LOG.debug("Timeout for host {} is not reached yet, skipping.".format(host_ref))
+                    LOG.debug("Timeout for host {} is not reached yet, skipping.".format(host_ref.value))
             else:
                 self.hosts_to_rectify[host_ref] = time.time()
                 hosts.add(host_ref)
@@ -724,18 +782,19 @@ class DVSController(object):
                 if obj.obj._type == 'Datacenter':
                     return obj.obj
 
-    def _get_pg_by_name(self, pg_name):
+    def _get_pg_by_name(self, pg_name, refresh_if_missing=True):
         """Get the dpg ref by name"""
-        for pg in self._get_all_port_groups():
+        try:
+            return self._port_groups_by_name[pg_name]["ref"]
+        except KeyError:
+            if not refresh_if_missing:
+                raise exceptions.PortGroupNotFound(pg_name=pg_name)
+
+            self._get_portgroups(refresh=True)
             try:
-                name = self.connection.invoke_api(
-                    vim_util, 'get_object_property',
-                    self.connection.vim, pg, 'name')
-                if pg_name == name:
-                    return pg
-            except vmware_exceptions.VimException:
-                pass
-        raise exceptions.PortGroupNotFound(pg_name=pg_name)
+                return self._port_groups_by_name[pg_name]["ref"]
+            except KeyError:
+                raise exceptions.PortGroupNotFound(pg_name=pg_name)
 
     def _get_all_port_groups(self):
         net_list = self.connection.invoke_api(
@@ -892,13 +951,13 @@ def connect(config, **kwds):
     return connection
 
 
-def create_network_map_from_config(config, connection=None, pool=None):
+def create_network_map_from_config(config, connection=None, **kwargs):
     """Creates physical network to dvs map from config"""
     connection = connection or connect(config)
     network_map = {}
     for network, dvs in six.iteritems(neutron_utils.parse_mappings(config.network_maps)):
-        network_map[network] = DVSController(dvs, connection=connection, pool=pool,
-                                             rectify_wait=config.host_rectify_timeout)
+        network_map[network] = DVSController(dvs, connection=connection,
+                                             rectify_wait=config.host_rectify_timeout, **kwargs)
     return network_map
 
 

--- a/networking_dvs/utils/dvs_util.py
+++ b/networking_dvs/utils/dvs_util.py
@@ -483,6 +483,14 @@ class DVSController(object):
 
         dvpg_name = dvportgroup_name(self.uuid, sg_set)
 
+        portgroups = self._get_portgroups()
+        if dvpg_name in portgroups:
+            existing = portgroups[dvpg_name]
+
+            if update:
+                self.update_dvportgroup(existing, port_config)
+            return existing
+
         try:
             pg_spec = self.builder.pg_config(port_config)
             pg_spec.name = dvpg_name
@@ -507,6 +515,7 @@ class DVSController(object):
 
             values = {"key": props["key"],
                       "ref": pg_ref,
+                      "name": dvpg_name,
                       "configVersion": 0,
                       "description": sg_set,
                       "defaultPortConfig": port_config
@@ -515,7 +524,7 @@ class DVSController(object):
             return values
         except vmware_exceptions.DuplicateName as dn:
             LOG.info("Untagged portgroup with matching name {} found, will update and use.".format(dvpg_name))
-            portgroups = self._get_portgroups()
+
             if dvpg_name not in portgroups:
                 portgroups = self._get_portgroups(refresh=True)
 

--- a/networking_dvs/utils/dvs_util.py
+++ b/networking_dvs/utils/dvs_util.py
@@ -135,13 +135,15 @@ class DVSController(object):
         self.hosts_to_rectify = {}
         self.rectify_wait = rectify_wait
 
-        self._port_groups_by_name = {}
         try:
             self._dvs, self._datacenter = self._get_dvs(dvs_name, connection)
             # (SlOPS) To do release blocked port after use
             self._blocked_ports = set()
         except vmware_exceptions.VimException as e:
             raise exceptions.wrap_wmvare_vim_exception(e)
+
+        self._port_groups_by_name = {}
+        self._get_portgroups(refresh=True)
 
     @property
     def uuid(self):

--- a/networking_dvs/utils/security_group_utils.py
+++ b/networking_dvs/utils/security_group_utils.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import abc
+import attr
 import copy
 import six
 import string
@@ -41,6 +42,33 @@ HASHED_RULE_INFO_KEYS = [
     'source_port_range_max'
 ]
 
+@attr.s(cmp=True, hash=True)
+class Rule(object):
+    direction = attr.ib(default=None)
+    ethertype = attr.ib(default=None)
+    protocol = attr.ib(default=None)
+
+    dest_ip_prefix = attr.ib(default=None)
+    port_range_min = attr.ib(default=None)
+    port_range_max = attr.ib(default=None)
+
+    source_ip_prefix = attr.ib(default=None)
+    source_port_range_min = attr.ib(default=None)
+    source_port_range_max = attr.ib(default=None)
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def get(self, key, default=None):
+        return self.__dict__[key] or default
+
+@attr.s(cmp=True, hash=True)
+class SgAggr(object):
+    pg_key = attr.ib(default=None)
+    vlan  = attr.ib(default=None)
+    rules = attr.ib(default=attr.Factory(dict))
+    ports_to_assign = attr.ib(default=attr.Factory(list))
+    dirty = attr.ib(default=True)
 
 class PortConfigSpecBuilder(spec_builder.SpecBuilder):
     def __init__(self, spec_factory):
@@ -81,7 +109,7 @@ class TrafficRuleBuilder(object):
         if protocol:
             int_exp = self.spec_builder.create_spec('ns0:IntExpression')
             int_exp.value = dvs_const.PROTOCOL.get(protocol, protocol)
-            int_exp.negate = 'false'
+            int_exp.negate = False
             self.ip_qualifier.protocol = int_exp
 
         self.name = name
@@ -135,10 +163,10 @@ class TrafficRuleBuilder(object):
             ip, mask = cidr.split('/')
         except ValueError:
             ip = cidr
-            mask = '32'
+            mask = 32
         result = self.spec_builder.create_spec('ns0:IpRange')
         result.addressPrefix = ip
-        result.prefixLength = mask
+        result.prefixLength = int(mask)
         return result
 
     def _has_port(self, min_port):
@@ -251,9 +279,8 @@ def port_configuration(builder, port_key, sg_rules, hashed_rules, version=None, 
     seq = 0
     reverse_seq = len(sg_rules) * 10
     for rule_info in sg_rules:
-        rule_hash = _get_rule_hash(rule_info)
-        if rule_hash in hashed_rules:
-            rule, reverse_rule = hashed_rules[rule_hash]
+        if rule_info in hashed_rules:
+            rule, reverse_rule = hashed_rules[rule_info]
             built_rule = copy.copy(rule)
             built_reverse_rule = copy.copy(reverse_rule)
             built_rule.description = str(seq) + '. regular'
@@ -267,7 +294,7 @@ def port_configuration(builder, port_key, sg_rules, hashed_rules, version=None, 
             cidr_revert = not _rule_excepted(rule)
             reverse_rule = rule.reverse(cidr_revert)
             built_reverse_rule = reverse_rule.build(reverse_seq)
-            hashed_rules[rule_hash] = (built_rule, built_reverse_rule)
+            hashed_rules[rule_info] = (built_rule, built_reverse_rule)
 
         rules.extend([built_rule, built_reverse_rule])
         seq += 10
@@ -297,14 +324,6 @@ def _rule_excepted(rule):
             rule.backward_port_range == (547, 547)):
                 return True
     return False
-
-
-def _get_rule_hash(rule):
-    rule_tokens = []
-    for k in sorted(rule):
-        if k in HASHED_RULE_INFO_KEYS:
-            rule_tokens.append('%s:%s' % (k, rule[k]))
-    return ','.join(rule_tokens)
 
 
 def _create_rule(builder, rule_info, ip=None, name=None):
@@ -340,15 +359,19 @@ def _patch_sg_rules(security_group_rules):
     patched_rules = []
 
     for rule in security_group_rules:
-        if not 'protocol' in rule:
-            for proto in ['icmp', 'udp', 'tcp']:
-                new_rule = rule.copy()
-                new_rule.update(protocol=proto,
-                                port_range_min=0,
-                                port_range_max=65535)
-                patched_rules.append(new_rule)
+        # Remove data, which is purely informational (at this point)
+        rule.pop('security_group_id', None)
+        rule.pop('remote_group_id', None)
+
+        if 'protocol' in rule:
+            patched_rules.append(Rule(**rule))
         else:
-            patched_rules.append(rule)
+            for proto in ['icmp', 'udp', 'tcp']:
+                new_rule = Rule(**rule)
+                new_rule.protocol=proto
+                new_rule.port_range_min=0
+                new_rule.port_range_max=65535
+                patched_rules.append(new_rule)
 
     return patched_rules
 
@@ -359,7 +382,7 @@ def security_group_set(port):
     A security group set is a comma-separated,
     sorted list of security group ids
     """
-    return string.join(sorted(port['security_groups']), ",")
+    return ",".join(sorted(port['security_groups']))
 
 def apply_rules(rules, sg_aggr, decrement=False):
     """
@@ -369,36 +392,25 @@ def apply_rules(rules, sg_aggr, decrement=False):
         "dirty": True|False
     """
 
-    if "rules" in sg_aggr:
-        sg_aggr_rules = sg_aggr["rules"]
-    else:
-        sg_aggr_rules = {}
-        sg_aggr["rules"] = sg_aggr_rules
-
-    if "dirty" not in sg_aggr:
-        sg_aggr["dirty"] = True
-
     for rule in rules:
-        comparable_rule = tuple(sorted(six.iteritems(rule)))
-        if comparable_rule in sg_aggr_rules:
-            count = sg_aggr_rules[comparable_rule]
+        if rule in sg_aggr.rules:
+            count = sg_aggr.rules[rule]
             if decrement:
                 count -= 1
                 if count == 0:
-                    del sg_aggr_rules[comparable_rule]
-                    sg_aggr["dirty"] = True
+                    del sg_aggr.rules[rule]
+                    sg_aggr.dirty = True
                     continue
             else:
                 count += 1
-            sg_aggr_rules[comparable_rule] = count
+            sg_aggr.rules[rule] = count
         else:
-            sg_aggr_rules[comparable_rule] = 1
-            sg_aggr["dirty"] = True
+            sg_aggr.rules[rule] = 1
+            sg_aggr.dirty = True
 
 def get_rules(sg_aggr):
     """
     Returns a list of the rules stored in a security group aggregate
     """
-    return [{t[0]: t[1] for t in x} for x in sg_aggr["rules"].keys()]
+    return sorted(six.iterkeys(sg_aggr.rules))
 
-#

--- a/networking_dvs/utils/security_group_utils.py
+++ b/networking_dvs/utils/security_group_utils.py
@@ -60,7 +60,7 @@ class Rule(object):
         return self.__dict__[key]
 
     def get(self, key, default=None):
-        return self.__dict__[key] or default
+        return self.__dict__.get(key, default)
 
 @attr.s(cmp=True, hash=True)
 class SgAggr(object):
@@ -272,7 +272,6 @@ def get_port_rules(client_factory, ports):
     hashed_rules = {}
     return build_port_rules(builder, ports, hashed_rules)
 
-
 def port_configuration(builder, port_key, sg_rules, hashed_rules, version=None, filter_config_key=None):
     sg_rules = sg_rules or []
     rules = []
@@ -348,10 +347,10 @@ def _create_rule(builder, rule_info, ip=None, name=None):
         rule.port_range = (rule_info.get('port_range_min'),
                            rule_info.get('port_range_max'))
         rule.backward_port_range = (
-            rule_info.get(
-                'source_port_range_min') or source_port_range_min_default,
-            rule_info.get(
-                'source_port_range_max') or dvs_const.MAX_EPHEMERAL_PORT)
+            rule_info.get('source_port_range_min',
+                          source_port_range_min_default),
+            rule_info.get('source_port_range_max',
+                          dvs_const.MAX_EPHEMERAL_PORT))
     return rule
 
 

--- a/networking_dvs/utils/spec_builder.py
+++ b/networking_dvs/utils/spec_builder.py
@@ -69,18 +69,18 @@ class SpecBuilder(object):
         filter_policy = self.factory.create('ns0:DvsFilterPolicy')
         if rules:
             traffic_ruleset = self.factory.create('ns0:DvsTrafficRuleset')
-            traffic_ruleset.enabled = '1'
+            traffic_ruleset.enabled = True
             traffic_ruleset.rules = rules
             filter_config = self.factory.create('ns0:DvsTrafficFilterConfig')
             filter_config.agentName = "dvfilter-generic-vmware"
-            filter_config.inherited = '0'
+            filter_config.inherited = False
             filter_config.trafficRuleset = traffic_ruleset
             if filter_config_key:
                 filter_config.key = filter_config_key
             filter_policy.filterConfig = [filter_config]
-            filter_policy.inherited = '0'
+            filter_policy.inherited = False
         else:
-            filter_policy.inherited = '1'
+            filter_policy.inherited = True
         return filter_policy
 
     def port_criteria(self, port_key=None, port_group_key=None,
@@ -101,7 +101,7 @@ class SpecBuilder(object):
     def vlan(self, vlan_tag):
         spec_ns = 'ns0:VmwareDistributedVirtualSwitchVlanIdSpec'
         spec = self.factory.create(spec_ns)
-        spec.inherited = '0'
+        spec.inherited = False
         spec.vlanId = vlan_tag
         return spec
 
@@ -109,9 +109,9 @@ class SpecBuilder(object):
         """Value should be True or False"""
         spec = self.factory.create('ns0:BoolPolicy')
         if value:
-            spec.inherited = '0'
-            spec.value = 'true'
+            spec.inherited = False
+            spec.value = True
         else:
-            spec.inherited = '1'
-            spec.value = 'false'
+            spec.inherited = False
+            spec.value = False
         return spec


### PR DESCRIPTION
The server side now checks, if the agent is of the new version, and if so queries `bridge_name`.

On the agent side, if it receives a port binding request, it will create new port-group for the security group, and return the name in `bridge_name`, if it is missing, otherwise it returns it directly.

The agent will now also read on startup the existing configuration on the port-group and avoid applying an update, if the config matches the desired one.
